### PR TITLE
Persist new activities to db.json

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,7 +113,7 @@ const handleAddActivity = async () => {
     },
   ]);
 
-  addActivity(
+  await addActivity(
     answers.name,
     answers.cost,
     answers.category,

--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -1,6 +1,7 @@
 import { Activity } from "../models";
 import { randomUUID } from "crypto";
 import { compareAsc } from "date-fns";
+import fs from "fs/promises";
 import dbData from "../../db.json";
 
 let activities: Activity[] = dbData.trips[0].activities.map(activity => ({
@@ -9,12 +10,12 @@ let activities: Activity[] = dbData.trips[0].activities.map(activity => ({
     category: activity.category as "food" | "transport" | "sightseeing"
 }));
 
-export const addActivity = (
-    name: string, 
-    cost: number, 
-    category: "food" | "transport" | "sightseeing", 
-    startTime: Date 
-): void => {
+export const addActivity = async (
+    name: string,
+    cost: number,
+    category: "food" | "transport" | "sightseeing",
+    startTime: Date
+): Promise<void> => {
 
     const newActivity: Activity = {
         id: randomUUID(),
@@ -24,6 +25,13 @@ export const addActivity = (
         startTime: startTime,
     }
     activities.push(newActivity)
+
+    // update db.json so the new activity persists
+    dbData.trips[0].activities = activities.map(a => ({
+        ...a,
+        startTime: a.startTime.toISOString(),
+    }));
+    await fs.writeFile("./db.json", JSON.stringify(dbData, null, 2));
 };
 
 


### PR DESCRIPTION
## Summary
- `addActivity` now writes back to `db.json` after adding to the in-memory array, so activities persist across sessions
- Budget calculations (`getTripTotalCost`, `findHighCostItem`) automatically pick up newly added activities since they already read from `db.json`

Closes #10

## Test plan
- [ ] Run the app, add a new activity, then exit
- [ ] Re-run the app and confirm the activity is still there
- [ ] Check that trip total cost includes the new activity